### PR TITLE
Begin porting support to net standard 1.5 (PageObjects left out for now)

### DIFF
--- a/dotnet/src/support/CoreCompat.WebDriver.Support.csproj
+++ b/dotnet/src/support/CoreCompat.WebDriver.Support.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD1_5</DefineConstants>
+    <DefaultItemExcludes>$(DefaultItemExcludes);PageObjects\**\*.cs</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <PackageReference Include="CoreCompat.System.Drawing" Version="1.0.0-beta006" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebDriver\CoreCompat.Selenium.WebDriver.csproj">
+      <Project>{83C13931-B27C-425C-AAF0-5F96EEA4F173}</Project>
+      <Name>WebDriver</Name>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/support/Extensions/WebDriverExtensions.cs
+++ b/dotnet/src/support/Extensions/WebDriverExtensions.cs
@@ -96,7 +96,11 @@ namespace OpenQA.Selenium.Support.Extensions
             Type type = typeof(T);
             if (value == null)
             {
-                if (type.IsValueType && (Nullable.GetUnderlyingType(type) == null))
+                #if !NETSTANDARD1_5
+                if (type.IsValueType)
+                #else
+                if (type.GetTypeInfo().IsValueType && (Nullable.GetUnderlyingType(type) == null))
+                #endif
                 {
                     throw new WebDriverException("Script returned null, but desired type is a value type");
                 }

--- a/dotnet/src/support/UI/DefaultWait{T}.cs
+++ b/dotnet/src/support/UI/DefaultWait{T}.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Reflection;
 
 namespace OpenQA.Selenium.Support.UI
 {
@@ -147,7 +148,11 @@ namespace OpenQA.Selenium.Support.UI
             }
 
             var resultType = typeof(TResult);
+            #if !NETSTANDARD1_5
             if ((resultType.IsValueType && resultType != typeof(bool)) || !typeof(object).IsAssignableFrom(resultType))
+            #else
+            if ((resultType.GetTypeInfo().IsValueType && resultType != typeof(bool)) || !typeof(object).IsAssignableFrom(resultType))
+            #endif
             {
                 throw new ArgumentException("Can only wait on an object or boolean response, tried to use type: " + resultType.ToString(), "condition");
             }

--- a/dotnet/src/support/UI/LoadableComponentException.cs
+++ b/dotnet/src/support/UI/LoadableComponentException.cs
@@ -25,7 +25,9 @@ namespace OpenQA.Selenium.Support.UI
     /// This exception is thrown by <see cref="LoadableComponent{T}"/> to indicate that
     /// the component was not successfully loaded.
     /// </summary>
+    #if !NETSTANDARD1_5
     [Serializable]
+    #endif
     public class LoadableComponentException : WebDriverException
     {
         /// <summary>
@@ -65,9 +67,11 @@ namespace OpenQA.Selenium.Support.UI
         /// object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual
         /// information about the source or destination.</param>
+        #if !NETSTANDARD1_5
         protected LoadableComponentException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+        #endif
     }
 }

--- a/dotnet/src/support/UI/UnexpectedTagNameException.cs
+++ b/dotnet/src/support/UI/UnexpectedTagNameException.cs
@@ -26,7 +26,9 @@ namespace OpenQA.Selenium.Support.UI
     /// The exception thrown when using the Select class on a tag that
     /// does not support the HTML select element's selection semantics.
     /// </summary>
+    #if !NETSTANDARD1_5
     [Serializable]
+    #endif
     public class UnexpectedTagNameException : WebDriverException
     {
         /// <summary>
@@ -77,9 +79,11 @@ namespace OpenQA.Selenium.Support.UI
         /// object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual
         /// information about the source or destination.</param>
+        #if !NETSTANDARD1_5
         protected UnexpectedTagNameException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+        #endif
     }
 }


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

So far I have left out PageObjects as they rely on `System.Runtime.Remoting` which doesn't seem to be available in dotnet core so far. The UI utils and the rest work fine however